### PR TITLE
Strange output behaviour on Quaternion when using rotation from 6 DOF input hardware

### DIFF
--- a/Assets/Scripts/FilterTestQuaternion.cs
+++ b/Assets/Scripts/FilterTestQuaternion.cs
@@ -58,8 +58,14 @@ public class FilterTestQuaternion : MonoBehaviour
 		}
 		else
 			filteredTransform.rotation = noisyTransform.rotation;
-	
-	}
+
+    }
+
+    //private void OnDrawGizmos()
+    //{
+    //    Gizmos.DrawSphere(new Vector3(noisyTransform.rotation.x, noisyTransform.rotation.y, noisyTransform.rotation.z) * 5 + Vector3.up * 5, 0.1f);
+    //    Gizmos.DrawSphere(new Vector3(noisyTransform.rotation.w, 0, 0) * 5 + Vector3.up * 5, 0.1f);
+    //}
 
 
 	Quaternion PerturbedRotation(Quaternion _rotation)

--- a/Assets/Scripts/OneEuroFilter.cs
+++ b/Assets/Scripts/OneEuroFilter.cs
@@ -283,6 +283,16 @@ public class OneEuroFilter<T> where T : struct
 		{
 			Quaternion output = Quaternion.identity;
 			Quaternion input = (Quaternion) Convert.ChangeType(_value, typeof(Quaternion));
+            
+            // Workaround that take into account that some input device sends
+            // quaternion that represent only a half of all possible values.
+            // this piece of code does not affect normal behaviour (when the
+            // input use the full range of possible values).
+            if (Vector4.SqrMagnitude(new Vector4(oneEuroFilters[0].currValue, oneEuroFilters[1].currValue, oneEuroFilters[2].currValue, oneEuroFilters[3].currValue).normalized
+                - new Vector4(input[0], input[1], input[2], input[3]).normalized) > 2)
+            {
+                input = new Quaternion(-input.x, -input.y, -input.z, -input.w);
+            }
 
 			for(int i = 0; i < oneEuroFilters.Length; i++)
 				output[i] = oneEuroFilters[i].Filter(input[i], timestamp);


### PR DESCRIPTION
I used your implementation of the 1€ Filter to filter the orientation of the HTC Vive controller.
I noticed that when pointing the controller in certain direction, the object that rotate with the controller behave strangely when using the filter.

I had to learn the internal functioning of a quaternion to understand the bug. Here is an explanation of what I understood and a commit that fix this issue for all kind of input hardware that have the same problem.

We know that a quaternion (x, y, z, w) represent the same rotation that (-x, -y, -z, -w).
So an input device has to send only one of the two quaternion to the software (assuming that we use only normalized quaternions).
For example, hardware like HTC Vive decided to send only quaternions with a positive y value.
This cause the w, x and z variables to jump to an opposite value when y reach 0, making the input quaternion non-continuous, even if the rotation is visually continuous. However, the filtered rotation become visually not continuous (we can see a quick 360 degree rotation of the object that use the filtered quaternion).

This pull request adds a workaround that make the output of the filter consistent even if the input is not.