### PR TITLE
Expose float filter & add default params for float UpdateParams

### DIFF
--- a/Assets/Scripts/OneEuroFilter.cs
+++ b/Assets/Scripts/OneEuroFilter.cs
@@ -139,7 +139,7 @@ public class OneEuroFilter
 		prevValue = currValue;
 	}
 
-	public void UpdateParams(float _freq, float _mincutoff, float _beta, float _dcutoff)
+	public void UpdateParams(float _freq, float _mincutoff = 1.0f, float _beta = 0.0f, float _dcutoff = 1.0f)
 	{
 		setFrequency(_freq);
 		setMinCutoff(_mincutoff);

--- a/Assets/Scripts/OneEuroFilter.cs
+++ b/Assets/Scripts/OneEuroFilter.cs
@@ -68,7 +68,7 @@ class LowPassFilter
 
 // -----------------------------------------------------------------
 
-class OneEuroFilter 
+public class OneEuroFilter 
 {
 	float freq;
 	float mincutoff;


### PR DESCRIPTION
Change `OneEuroFilter`'s scope to be public and add default parameters for non-frequency values in its `UpdateParams` method 

Resolves this issue: https://github.com/DarioMazzanti/OneEuroFilterUnity/issues/4